### PR TITLE
add metrics flag to osht

### DIFF
--- a/oshinko_temaki/cli.py
+++ b/oshinko_temaki/cli.py
@@ -32,17 +32,23 @@ def main():
                         dest="crd",
                         help="set if the output should be a CRD",
                         action="store_true")
+    parser.add_argument("-t", "--metrics",
+                        dest="metrics",
+                        help="enable metrics deployment",
+                        action="store_true")
     args = parser.parse_args()
     if args.crd is True:
         cluster = templates.CRDTemplate(args.name,
                                         args.masters,
                                         args.workers,
-                                        args.image)
+                                        args.image,
+                                        args.metrics)
     else:
         cluster = templates.CMTemplate(args.name,
                                        args.masters,
                                        args.workers,
-                                       args.image)
+                                       args.image,
+                                       args.metrics)
     print(cluster.dumps())
 
 

--- a/oshinko_temaki/templates.py
+++ b/oshinko_temaki/templates.py
@@ -4,29 +4,41 @@ import yaml
 
 
 class BaseTemplate():
+    def __init__(self, name, masters, workers, image, metrics):
+        self.name = name
+        self.masters = masters
+        self.workers = workers
+        self.image = image
+        self.metrics = metrics
+
     def dumps(self):
         return json.dumps(self._data)
 
 
 class CMTemplate(BaseTemplate):
-    def __init__(self, name, masters, workers, image):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         data = {
             "master": {
-                "instances": masters
+                "instances": self.masters
             },
             "worker": {
-                "instances": workers
+                "instances": self.workers
             }
         }
 
-        if image is not None:
-            data["customImage"] = image
+        if self.image is not None:
+            data["customImage"] = self.image
+
+        if self.metrics is True:
+            data["metrics"] = True
 
         self._data = {
             "apiVersion": "v1",
             "kind": "ConfigMap",
             "metadata": {
-                "name": name,
+                "name": self.name,
                 "labels": {
                     "radanalytics.io/kind": "SparkCluster"
                 }
@@ -38,22 +50,27 @@ class CMTemplate(BaseTemplate):
 
 
 class CRDTemplate(BaseTemplate):
-    def __init__(self, name, masters, workers, image):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self._data = {
             "apiVersion": "radanalytics.io/v1",
             "kind": "SparkCluster",
             "metadata": {
-                "name": name
+                "name": self.name
             },
             "spec": {
                 "master": {
-                    "instances": int(masters)
+                    "instances": int(self.masters)
                 },
                 "worker": {
-                    "instances": int(workers)
+                    "instances": int(self.workers)
                 }
             }
         }
 
-        if image is not None:
-            self._data["spec"]["customImage"] = image
+        if self.image is not None:
+            self._data["spec"]["customImage"] = self.image
+        
+        if self.metrics is True:
+            self._data["spec"]["metrics"] = True


### PR DESCRIPTION
This adds the metrics flag to the command line for enabling prometheus
metrics on spark cluster. It also refactors the templates classes a
little by moving the arguments to the base class to make it easier on
maintenance when adding new options.